### PR TITLE
Add kde support for linux with dirty hacks 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ description = "A library for set/get system proxy. Supports Windows, macOS and l
 [dependencies]
 thiserror = "1"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+xdg = "^2.5"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 interfaces = "0.0.8"
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # sysproxy-rs
 
-A library for set/get system proxy. Supports Windows, macOS and linux (via gsettings).
+A library for set/get system proxy. Supports Windows, macOS and linux (via gsettings/kconfig).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,13 @@ pub enum Error {
 
     #[error("failed to get default network interface")]
     NetworkInterface,
+
+    #[error("failed to set proxy for this environment")]
+    NotSupport,
+
+    #[cfg(target_os = "linux")]
+    #[error(transparent)]
+    Xdg(#[from] xdg::BaseDirectoriesError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,5 +1,6 @@
 use crate::{Error, Result, Sysproxy};
-use std::{process::Command, str::from_utf8};
+use std::{env, process::Command, str::from_utf8};
+use xdg;
 
 const CMD_KEY: &str = "org.gnome.system.proxy";
 
@@ -42,27 +43,80 @@ impl Sysproxy {
     }
 
     pub fn get_enable() -> Result<bool> {
-        let mode = gsettings().args(["get", CMD_KEY, "mode"]).output()?;
-        let mode = from_utf8(&mode.stdout).or(Err(Error::ParseStr))?.trim();
-        Ok(mode == "'manual'")
+        match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+            "GNOME" => {
+                let mode = gsettings().args(["get", CMD_KEY, "mode"]).output()?;
+                let mode = from_utf8(&mode.stdout).or(Err(Error::ParseStr))?.trim();
+                Ok(mode == "'manual'")
+            }
+            "KDE" => {
+                let xdg_dir = xdg::BaseDirectories::new()?;
+                let config = xdg_dir.get_config_file("kioslaverc");
+                let config = config.to_str().ok_or(Error::ParseStr)?;
+
+                let mode = kreadconfig()
+                    .args([
+                        "--file",
+                        config,
+                        "--group",
+                        "Proxy Settings",
+                        "--key",
+                        "ProxyType",
+                    ])
+                    .output()?;
+                let mode = from_utf8(&mode.stdout).or(Err(Error::ParseStr))?.trim();
+                Ok(mode == "1")
+            }
+            _ => Err(Error::NotSupport),
+        }
     }
 
     pub fn get_bypass() -> Result<String> {
-        let bypass = gsettings()
-            .args(["get", CMD_KEY, "ignore-hosts"])
-            .output()?;
-        let bypass = from_utf8(&bypass.stdout).or(Err(Error::ParseStr))?.trim();
+        match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+            "GNOME" => {
+                let bypass = gsettings()
+                    .args(["get", CMD_KEY, "ignore-hosts"])
+                    .output()?;
+                let bypass = from_utf8(&bypass.stdout).or(Err(Error::ParseStr))?.trim();
 
-        let bypass = bypass.strip_prefix('[').unwrap_or(bypass);
-        let bypass = bypass.strip_suffix(']').unwrap_or(bypass);
+                let bypass = bypass.strip_prefix('[').unwrap_or(bypass);
+                let bypass = bypass.strip_suffix(']').unwrap_or(bypass);
 
-        let bypass = bypass
-            .split(',')
-            .map(|h| strip_str(h.trim()))
-            .collect::<Vec<&str>>()
-            .join(",");
+                let bypass = bypass
+                    .split(',')
+                    .map(|h| strip_str(h.trim()))
+                    .collect::<Vec<&str>>()
+                    .join(",");
 
-        Ok(bypass)
+                Ok(bypass)
+            }
+            "KDE" => {
+                let xdg_dir = xdg::BaseDirectories::new()?;
+                let config = xdg_dir.get_config_file("kioslaverc");
+                let config = config.to_str().ok_or(Error::ParseStr)?;
+
+                let bypass = kreadconfig()
+                    .args([
+                        "--file",
+                        config,
+                        "--group",
+                        "Proxy Settings",
+                        "--key",
+                        "NoProxyFor",
+                    ])
+                    .output()?;
+                let bypass = from_utf8(&bypass.stdout).or(Err(Error::ParseStr))?.trim();
+
+                let bypass = bypass
+                    .split(',')
+                    .map(|h| strip_str(h.trim()))
+                    .collect::<Vec<&str>>()
+                    .join(",");
+
+                Ok(bypass)
+            }
+            _ => Err(Error::NotSupport),
+        }
     }
 
     pub fn get_http() -> Result<Sysproxy> {
@@ -78,34 +132,80 @@ impl Sysproxy {
     }
 
     pub fn set_enable(&self) -> Result<()> {
-        let mode = if self.enable { "'manual'" } else { "'none'" };
-        gsettings().args(["set", CMD_KEY, "mode", mode]).status()?;
-        Ok(())
+        match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+            "GNOME" => {
+                let mode = if self.enable { "'manual'" } else { "'none'" };
+                gsettings().args(["set", CMD_KEY, "mode", mode]).status()?;
+                Ok(())
+            }
+            "KDE" => {
+                let xdg_dir = xdg::BaseDirectories::new()?;
+                let config = xdg_dir.get_config_file("kioslaverc");
+                let config = config.to_str().ok_or(Error::ParseStr)?;
+                let mode = if self.enable { "1" } else { "0" };
+                kwriteconfig()
+                    .args([
+                        "--file",
+                        config,
+                        "--group",
+                        "Proxy Settings",
+                        "--key",
+                        "ProxyType",
+                        mode,
+                    ])
+                    .status()?;
+                Ok(())
+            }
+            _ => Err(Error::NotSupport),
+        }
     }
 
     pub fn set_bypass(&self) -> Result<()> {
-        let bypass = self
-            .bypass
-            .split(',')
-            .map(|h| {
-                let mut host = String::from(h.trim());
-                if !host.starts_with('\'') && !host.starts_with('"') {
-                    host = String::from("'") + &host;
-                }
-                if !host.ends_with('\'') && !host.ends_with('"') {
-                    host = host + "'";
-                }
-                host
-            })
-            .collect::<Vec<String>>()
-            .join(", ");
+        match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+            "GNOME" => {
+                let bypass = self
+                    .bypass
+                    .split(',')
+                    .map(|h| {
+                        let mut host = String::from(h.trim());
+                        if !host.starts_with('\'') && !host.starts_with('"') {
+                            host = String::from("'") + &host;
+                        }
+                        if !host.ends_with('\'') && !host.ends_with('"') {
+                            host = host + "'";
+                        }
+                        host
+                    })
+                    .collect::<Vec<String>>()
+                    .join(", ");
 
-        let bypass = format!("[{bypass}]");
+                let bypass = format!("[{bypass}]");
 
-        gsettings()
-            .args(["set", CMD_KEY, "ignore-hosts", bypass.as_str()])
-            .status()?;
-        Ok(())
+                gsettings()
+                    .args(["set", CMD_KEY, "ignore-hosts", bypass.as_str()])
+                    .status()?;
+                Ok(())
+            }
+            "KDE" => {
+                let xdg_dir = xdg::BaseDirectories::new()?;
+                let config = xdg_dir.get_config_file("kioslaverc");
+                let config = config.to_str().ok_or(Error::ParseStr)?;
+
+                kwriteconfig()
+                    .args([
+                        "--file",
+                        config,
+                        "--group",
+                        "Proxy Settings",
+                        "--key",
+                        "NoProxyFor",
+                        self.bypass.as_str(),
+                    ])
+                    .status()?;
+                Ok(())
+            }
+            _ => Err(Error::NotSupport),
+        }
     }
 
     pub fn set_http(&self) -> Result<()> {
@@ -125,39 +225,119 @@ fn gsettings() -> Command {
     Command::new("gsettings")
 }
 
+fn kreadconfig() -> Command {
+    Command::new("kreadconfig5")
+}
+
+fn kwriteconfig() -> Command {
+    Command::new("kwriteconfig5")
+}
+
 fn set_proxy(proxy: &Sysproxy, service: &str) -> Result<()> {
-    let schema = format!("{CMD_KEY}.{service}");
-    let schema = schema.as_str();
+    match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+        "GNOME" => {
+            let schema = format!("{CMD_KEY}.{service}");
+            let schema = schema.as_str();
 
-    let host = format!("'{}'", proxy.host);
-    let host = host.as_str();
-    let port = format!("{}", proxy.port);
-    let port = port.as_str();
+            let host = format!("'{}'", proxy.host);
+            let host = host.as_str();
+            let port = format!("{}", proxy.port);
+            let port = port.as_str();
 
-    gsettings().args(["set", schema, "host", host]).status()?;
-    gsettings().args(["set", schema, "port", port]).status()?;
+            gsettings().args(["set", schema, "host", host]).status()?;
+            gsettings().args(["set", schema, "port", port]).status()?;
 
-    Ok(())
+            Ok(())
+        }
+        "KDE" => {
+            let xdg_dir = xdg::BaseDirectories::new()?;
+            let config = xdg_dir.get_config_file("kioslaverc");
+            let config = config.to_str().ok_or(Error::ParseStr)?;
+
+            let key = format!("{service}Proxy");
+            let key = key.as_str();
+
+            let service = match service {
+                "socks" => "socks",
+                _ => "http",
+            };
+
+            let host = format!("{}", proxy.host);
+            let host = host.as_str();
+            let port = format!("{}", proxy.port);
+            let port = port.as_str();
+
+            let schema = format!("{service}://{host} {port}");
+            let schema = schema.as_str();
+
+            kwriteconfig()
+                .args([
+                    "--file",
+                    config,
+                    "--group",
+                    "Proxy Settings",
+                    "--key",
+                    key,
+                    schema,
+                ])
+                .status()?;
+
+            Ok(())
+        }
+        _ => Err(Error::NotSupport),
+    }
 }
 
 fn get_proxy(service: &str) -> Result<Sysproxy> {
-    let schema = format!("{CMD_KEY}.{service}");
-    let schema = schema.as_str();
+    match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+        "GNOME" => {
+            let schema = format!("{CMD_KEY}.{service}");
+            let schema = schema.as_str();
 
-    let host = gsettings().args(["get", schema, "host"]).output()?;
-    let host = from_utf8(&host.stdout).or(Err(Error::ParseStr))?.trim();
-    let host = strip_str(host);
+            let host = gsettings().args(["get", schema, "host"]).output()?;
+            let host = from_utf8(&host.stdout).or(Err(Error::ParseStr))?.trim();
+            let host = strip_str(host);
 
-    let port = gsettings().args(["get", schema, "port"]).output()?;
-    let port = from_utf8(&port.stdout).or(Err(Error::ParseStr))?.trim();
-    let port = port.parse().unwrap_or(80u16);
+            let port = gsettings().args(["get", schema, "port"]).output()?;
+            let port = from_utf8(&port.stdout).or(Err(Error::ParseStr))?.trim();
+            let port = port.parse().unwrap_or(80u16);
 
-    Ok(Sysproxy {
-        enable: false,
-        host: String::from(host),
-        port,
-        bypass: "".into(),
-    })
+            Ok(Sysproxy {
+                enable: false,
+                host: String::from(host),
+                port,
+                bypass: "".into(),
+            })
+        }
+        "KDE" => {
+            let xdg_dir = xdg::BaseDirectories::new()?;
+            let config = xdg_dir.get_config_file("kioslaverc");
+            let config = config.to_str().ok_or(Error::ParseStr)?;
+
+            let key = format!("{service}Proxy");
+            let key = key.as_str();
+
+            let schema = kreadconfig()
+                .args(["--file", config, "--group", "Proxy Settings", "--key", key])
+                .output()?;
+            let schema = from_utf8(&schema.stdout).or(Err(Error::ParseStr))?.trim();
+            let schema = schema
+                .trim_start_matches("http://")
+                .trim_start_matches("socks://");
+            let schema = schema.split_once(' ').ok_or(Error::ParseStr)?;
+
+            let host = strip_str(schema.0);
+            let port = schema.1.parse().unwrap_or(80u16);
+
+            Ok(Sysproxy {
+                enable: false,
+                host: String::from(host),
+                port,
+                bypass: "".into(),
+            })
+        }
+        _ => Err(Error::NotSupport),
+    }
 }
 
 fn strip_str<'a>(text: &'a str) -> &'a str {


### PR DESCRIPTION
Simply put some kconfig system proxy related commands modified from [Qv2ray](https://github.com/Qv2ray/Qv2ray/blob/dev/src/components/proxy/QvProxyConfigurator.cpp#L314C68-L314C68) to support KDE Plasma environment.

May require some sort of refactor in order to handle error gently (as for now DEs not GNOME nor KDE would simply return an Error) and/or provide a better interface as I'm not quite familiar with Rust and this is only the simplest hack I could came up with. 